### PR TITLE
Fix Server Crash, Cleanup

### DIFF
--- a/src/main/java/com/traverse/bhc/client/ClientBaubleyHeartCanisters.java
+++ b/src/main/java/com/traverse/bhc/client/ClientBaubleyHeartCanisters.java
@@ -2,16 +2,22 @@ package com.traverse.bhc.client;
 
 import com.traverse.bhc.common.BaubleyHeartCanisters;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.event.TextureStitchEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
 
+import static net.minecraftforge.fml.common.Mod.EventBusSubscriber.Bus.MOD;
 
+@Mod.EventBusSubscriber(modid = BaubleyHeartCanisters.MODID, bus = MOD)
 public class ClientBaubleyHeartCanisters {
 
     public static final ResourceLocation SLOT_TEXTURE = new ResourceLocation(BaubleyHeartCanisters.MODID, "slots/empty_heartamulet");
 
+    @OnlyIn(Dist.CLIENT)
     @SubscribeEvent
-    public void textureStitch(final TextureStitchEvent.Pre evt) {
+    public static void textureStitch(final TextureStitchEvent.Pre evt) {
         evt.addSprite(ClientBaubleyHeartCanisters.SLOT_TEXTURE);
     }
 }

--- a/src/main/java/com/traverse/bhc/client/ClientBaubleyHeartCanisters.java
+++ b/src/main/java/com/traverse/bhc/client/ClientBaubleyHeartCanisters.java
@@ -2,22 +2,16 @@ package com.traverse.bhc.client;
 
 import com.traverse.bhc.common.BaubleyHeartCanisters;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.event.TextureStitchEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.common.Mod;
 
-import static net.minecraftforge.fml.common.Mod.EventBusSubscriber.Bus.MOD;
 
-@Mod.EventBusSubscriber(modid = BaubleyHeartCanisters.MODID, value = Dist.CLIENT, bus = MOD)
 public class ClientBaubleyHeartCanisters {
 
     public static final ResourceLocation SLOT_TEXTURE = new ResourceLocation(BaubleyHeartCanisters.MODID, "slots/empty_heartamulet");
 
-    @OnlyIn(Dist.CLIENT)
     @SubscribeEvent
-    public static void textureStitch(final TextureStitchEvent.Pre evt) {
+    public void textureStitch(final TextureStitchEvent.Pre evt) {
         evt.addSprite(ClientBaubleyHeartCanisters.SLOT_TEXTURE);
     }
 }

--- a/src/main/java/com/traverse/bhc/client/proxy/ClientProxy.java
+++ b/src/main/java/com/traverse/bhc/client/proxy/ClientProxy.java
@@ -1,10 +1,12 @@
 package com.traverse.bhc.client.proxy;
 
+import com.traverse.bhc.client.ClientBaubleyHeartCanisters;
 import com.traverse.bhc.client.screens.HeartAmuletScreen;
 import com.traverse.bhc.client.screens.SoulHeartAmuletScreen;
 import com.traverse.bhc.common.init.RegistryHandler;
 import com.traverse.bhc.common.proxy.CommonProxy;
 import net.minecraft.client.gui.screens.MenuScreens;
+import net.minecraftforge.common.MinecraftForge;
 
 public class ClientProxy extends CommonProxy {
 
@@ -12,6 +14,7 @@ public class ClientProxy extends CommonProxy {
     public void doClientStuff() {
         MenuScreens.register(RegistryHandler.HEART_AMUlET_CONTAINER.get(), HeartAmuletScreen::new);
         MenuScreens.register(RegistryHandler.SOUL_HEART_AMUlET_CONTAINER.get(), SoulHeartAmuletScreen::new);
+        MinecraftForge.EVENT_BUS.register(new ClientBaubleyHeartCanisters());
         super.doClientStuff();
     }
 }

--- a/src/main/java/com/traverse/bhc/client/proxy/ClientProxy.java
+++ b/src/main/java/com/traverse/bhc/client/proxy/ClientProxy.java
@@ -1,12 +1,10 @@
 package com.traverse.bhc.client.proxy;
 
-import com.traverse.bhc.client.ClientBaubleyHeartCanisters;
 import com.traverse.bhc.client.screens.HeartAmuletScreen;
 import com.traverse.bhc.client.screens.SoulHeartAmuletScreen;
 import com.traverse.bhc.common.init.RegistryHandler;
 import com.traverse.bhc.common.proxy.CommonProxy;
 import net.minecraft.client.gui.screens.MenuScreens;
-import net.minecraftforge.common.MinecraftForge;
 
 public class ClientProxy extends CommonProxy {
 
@@ -14,7 +12,6 @@ public class ClientProxy extends CommonProxy {
     public void doClientStuff() {
         MenuScreens.register(RegistryHandler.HEART_AMUlET_CONTAINER.get(), HeartAmuletScreen::new);
         MenuScreens.register(RegistryHandler.SOUL_HEART_AMUlET_CONTAINER.get(), SoulHeartAmuletScreen::new);
-        MinecraftForge.EVENT_BUS.register(new ClientBaubleyHeartCanisters());
         super.doClientStuff();
     }
 }

--- a/src/main/java/com/traverse/bhc/common/BaubleyHeartCanisters.java
+++ b/src/main/java/com/traverse/bhc/common/BaubleyHeartCanisters.java
@@ -8,6 +8,7 @@ import com.traverse.bhc.common.config.BHCConfig;
 import com.traverse.bhc.common.config.ConfigHandler;
 import com.traverse.bhc.common.init.RegistryHandler;
 import com.traverse.bhc.common.proxy.CommonProxy;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.fml.DistExecutor;

--- a/src/main/java/com/traverse/bhc/common/BaubleyHeartCanisters.java
+++ b/src/main/java/com/traverse/bhc/common/BaubleyHeartCanisters.java
@@ -4,23 +4,17 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.traverse.bhc.client.ClientBaubleyHeartCanisters;
 import com.traverse.bhc.client.proxy.ClientProxy;
-import com.traverse.bhc.client.screens.HeartAmuletScreen;
-import com.traverse.bhc.client.screens.SoulHeartAmuletScreen;
 import com.traverse.bhc.common.config.BHCConfig;
 import com.traverse.bhc.common.config.ConfigHandler;
 import com.traverse.bhc.common.init.RegistryHandler;
 import com.traverse.bhc.common.proxy.CommonProxy;
-import net.minecraft.client.gui.screens.MenuScreens;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.InterModComms;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
-import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.InterModEnqueueEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
@@ -65,7 +59,6 @@ public class BaubleyHeartCanisters {
 
     private void enqueue(InterModEnqueueEvent event) {
         InterModComms.sendTo(CuriosApi.MODID, SlotTypeMessage.REGISTER_TYPE, () -> new SlotTypeMessage.Builder("heartamulet").icon(ClientBaubleyHeartCanisters.SLOT_TEXTURE).build());
-
     }
 
     /*private void doClientStuff(final FMLClientSetupEvent event) {

--- a/src/main/java/com/traverse/bhc/common/proxy/CommonProxy.java
+++ b/src/main/java/com/traverse/bhc/common/proxy/CommonProxy.java
@@ -1,12 +1,8 @@
 package com.traverse.bhc.common.proxy;
 
-import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
-
 public class CommonProxy {
 
     public void doClientStuff() {
 
     }
-
-
 }

--- a/src/main/java/com/traverse/bhc/common/util/HealthModifier.java
+++ b/src/main/java/com/traverse/bhc/common/util/HealthModifier.java
@@ -51,7 +51,7 @@ public class HealthModifier {
                     Optional<ImmutableTriple<String, Integer, ItemStack>> stackOptional = CuriosApi.getCuriosHelper().findEquippedCurio(RegistryHandler.HEART_AMULET.get(), livingEntity);
 
                     stackOptional.ifPresent(triple -> {
-                        if(livingEntity instanceof Player) {
+                        if (livingEntity instanceof Player) {
                             ItemStack stack = triple.getRight();
                             updatePlayerHealth((Player) livingEntity, stack, true);
                         }
@@ -65,8 +65,8 @@ public class HealthModifier {
 
                 @Override
                 public void onUnequip(SlotContext slotContext, ItemStack newStack) {
-                    if(slotContext.getWearer() instanceof Player)
-                        updatePlayerHealth((Player) slotContext.getWearer(), ItemStack.EMPTY, false);
+                    if (slotContext.entity() instanceof Player player)
+                        updatePlayerHealth(player, ItemStack.EMPTY, false);
                 }
 
             };
@@ -82,8 +82,7 @@ public class HealthModifier {
             };
 
             event.addCapability(CuriosCapability.ID_ITEM, provider);
-        }
-        else if(event.getObject().getItem() == RegistryHandler.SOUL_HEART_AMULET.get()) {
+        } else if (event.getObject().getItem() == RegistryHandler.SOUL_HEART_AMULET.get()) {
             ICurio curio = new ICurio() {
 
                 @Override
@@ -97,7 +96,7 @@ public class HealthModifier {
                     Optional<ImmutableTriple<String, Integer, ItemStack>> stackOptional = CuriosApi.getCuriosHelper().findEquippedCurio(RegistryHandler.SOUL_HEART_AMULET.get(), livingEntity);
 
                     stackOptional.ifPresent(triple -> {
-                        if(livingEntity instanceof Player) {
+                        if (livingEntity instanceof Player) {
                             ItemStack stack = triple.getRight();
                             updatePlayerHealth((Player) livingEntity, stack, true);
                         }
@@ -111,7 +110,7 @@ public class HealthModifier {
 
                 @Override
                 public void onUnequip(SlotContext slotContext, ItemStack newStack) {
-                    if(slotContext.getWearer() instanceof Player)
+                    if (slotContext.getWearer() instanceof Player)
                         updatePlayerHealth((Player) slotContext.getWearer(), ItemStack.EMPTY, false);
                 }
 
@@ -139,15 +138,14 @@ public class HealthModifier {
 
         int[] hearts = new int[4];
 
-        if(addHealth && !stack.isEmpty()) {
-            int[] amuletHearts = new int[0];
-            if(stack.getItem() instanceof ItemHeartAmulet amulet) {
+        if (addHealth && !stack.isEmpty()) {
+            int[] amuletHearts = null;
+            if (stack.getItem() instanceof ItemHeartAmulet amulet) {
+                amuletHearts = amulet.getHeartCount(stack);
+            } else if (stack.getItem() instanceof ItemSoulHeartAmulet amulet) {
                 amuletHearts = amulet.getHeartCount(stack);
             }
-            else if(stack.getItem() instanceof ItemSoulHeartAmulet amulet) {
-                amuletHearts = amulet.getHeartCount(stack);
-            }
-            Preconditions.checkArgument(amuletHearts.length == HeartType.values().length, "Array must be same length as enum length!");
+            Preconditions.checkArgument(amuletHearts != null, "amuletHearts was never initialized - is this a soul canister?");
             for (int i = 0; i < hearts.length; i++) {
                 hearts[i] += amuletHearts[i];
             }

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,5 +1,5 @@
 modLoader="javafml"
-loaderVersion="[37,)"
+loaderVersion="[43,)"
 license="MIT"
 issueTrackerURL="https://github.com/Traverse-Joe/Baubley-Heart-Canisters/issues"
 
@@ -16,6 +16,6 @@ Heart Canisters for Baubles/Curios Enjoy :D
 [[dependencies.bhc]]
     modId="forge"
     mandatory=true
-    versionRange="[37,)"
+    versionRange="[43,)"
     ordering="NONE"
     side="BOTH"


### PR DESCRIPTION
Fixes server compilation failure in `ClientBaubleyHeartCanisters.java`, because `Dist.CLIENT` is not known to the server so this static subscriber class fails on servers. Fixed by making it less static and instantiating it + registering it with `MinecraftForge.EVENT_BUS.register(new ClientBaubleyHeartCanisters());`

Fix the server canister bug with my changes in [`HealthModifier.java`](https://github.com/Traverse-Joe/Baubley-Heart-Canisters/compare/1.19...oitsjustjose:Baubley-Heart-Canisters:1.19?expand=1#diff-640f8801eaf340b323b3992bc705cd941db527752c295f77efa381200ce47d09). 

Cleaned up some code (imports, mostly) and fixed your required Forge version being really old.